### PR TITLE
Convert Chat component to TypeScript and use as default view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,8 @@
-import { useState } from 'react'
 import './App.css'
+import Chat from './pages/Chat'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <h1>Vite + React + TypeScript</h1>
-      <div className="card">
-        <button onClick={() => setCount((c) => c + 1)}>
-          count is {count}
-        </button>
-      </div>
-    </>
-  )
+  return <Chat />
 }
 
 export default App


### PR DESCRIPTION
## Summary
- Refactor Chat component with TypeScript interfaces and typed hooks
- Show the Chat screen by default via App component

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build` *(fails: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f8b0f4948324a6c7261922cba1f9