### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ A simple React application built with [Vite](https://vitejs.dev/) and TypeScript
    ```bash
    npm run build
    ```
+
+## Deployment
+
+This project is deployed to GitHub Pages. The site is automatically built and published whenever changes are pushed to the `main` branch.
+
+To preview the production build locally:
+
+```bash
+npm run build
+npm run preview
+```

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-})
+  // Use a different base path when building for GitHub Pages
+  base: mode === 'production' ? '/w1sh/' : '/',
+}))


### PR DESCRIPTION
## Summary
- configure Vite base path for GitHub Pages builds
- add workflow to build and deploy to GitHub Pages
- document automatic deployment in README

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b60c34168483249a5408c00561b21f