### PR TITLE
Add console transition callback to Chat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,11 @@ import Console from './pages/Console'
 import useGameState from './hooks/useGameState'
 
 function App() {
-  const { page } = useGameState()
+  const { page, onChatComplete } = useGameState()
 
   return (
     <div className="app-container">
-      {page === 'console' ? <Console /> : <Chat />}
+      {page === 'console' ? <Console /> : <Chat onComplete={onChatComplete} />}
     </div>
   )
 }

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -34,6 +34,8 @@ export default function useGameState() {
 
   const setPage = (page: Page): void => setState(prev => ({ ...prev, page }))
 
-  return { page: state.page, setPage }
+  const onChatComplete = (): void => setPage('console')
+
+  return { page: state.page, setPage, onChatComplete }
 }
 

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -5,7 +5,11 @@ interface Message {
     text: string;
 }
 
-export default function Chat(): JSX.Element {
+interface ChatProps {
+    onComplete?: () => void;
+}
+
+export default function Chat({ onComplete }: ChatProps): JSX.Element {
     const css = `
   /* === Scoped styles inside component === */
   .baylike {
@@ -136,6 +140,7 @@ export default function Chat(): JSX.Element {
             setDone(true);
             setAwaitingSend(false);
             setComposerText("");
+            if (onComplete) onComplete();
             return;
         }
         const line = script[idxRef.current];


### PR DESCRIPTION
## Summary
- add optional `onComplete` prop to Chat and fire it when conversation ends
- expose `onChatComplete` from `useGameState` to move to console page
- pass completion callback from App to Chat so game navigates to console automatically

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b60f75f52483248e5c17c9c20d88b6