### PR TITLE
Avoid duplicate console boot output and clean self-test line

### DIFF
--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -1,8 +1,11 @@
 // @ts-nocheck
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function Console(): JSX.Element {
+  const booted = useRef(false);
   useEffect(() => {
+    if (booted.current) return;
+    booted.current = true;
 
 (function(){
   // ----- Utility -----
@@ -352,11 +355,12 @@ export default function Console(): JSX.Element {
       setTimeout(()=>{ println('HIMEM is testing extended memory... done.'); }, 400);
       setTimeout(()=>{ println('\nMicrosoft(R) MS-DOS(R) Version 6.22'); }, 900);
       setTimeout(()=>{ println('Copyright (C) Microsoft Corp 1981-1994.'); }, 1200);
-      setTimeout(()=>{ if(fromReboot) beep(660,90); drawPrompt(); setTimeout(()=>{ // run quick, quiet tests once
+      setTimeout(()=>{
+        if(fromReboot) beep(660,90);
         const pass = runSelfTests(false);
         println(pass? 'Self-tests: PASS' : 'Self-tests: FAIL (type TESTS for details)');
         drawPrompt();
-      }, 300); }, 1500);
+      }, 1500);
     }, 700);
   }
 


### PR DESCRIPTION
## Summary
- ensure console boot runs only once by guarding useEffect with a ref
- run self-tests before showing command prompt so the result isn't prefixed with `C:>`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b6122ce03083248e111baa7b6c2650