### PR TITLE
Fix Console wrapper sizing to match App container

### DIFF
--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -387,7 +387,7 @@ export default function Console(): JSX.Element {
     margin:0; background: #0c0f0c; color:#d9ffe6; font: 14px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
     display:flex; flex-direction:column; gap:8px;
   }
-  .wrap{ display:flex; flex-direction:column; height:100vh; }
+  .wrap{ display:flex; flex-direction:column; width:100%; height:100%; }
 
   /* --- CRT Screen --- */
   .crt{


### PR DESCRIPTION
## Summary
- Ensure Console's wrapper fills its parent dimensions so it doesn't overflow `app-container`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b611d2c7e883249fb71443fe9cc67d