### PR TITLE
Fix ad image path for production base

### DIFF
--- a/src/pages/AdPage.tsx
+++ b/src/pages/AdPage.tsx
@@ -103,7 +103,7 @@ export default function AdPage({ onMessageSeller }: { onMessageSeller: () => voi
           {/* LEFT: media */}
           <article className="card media">
             <img
-              src="/images/w1sh-ad2.png"
+              src={`${import.meta.env.BASE_URL}images/w1sh-ad2.png`}
               alt="W1-SH handheld device"
               style={{ width: "100%", display: "block" }}
             />


### PR DESCRIPTION
## Summary
- load ad image relative to Vite base URL to prevent 404s in production

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68d72cbf483249aeff71ef0ad7a5d