### PR TITLE
Add bottom toolbar with new game reset button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,4 +2,29 @@
   width: min(100vw, calc(100vh * 9 / 16));
   aspect-ratio: 9 / 16;
   display: flex;
+  flex-direction: column;
+}
+
+.app-content {
+  flex: 1;
+  display: flex;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  background: #111b25;
+  border-top: 1px solid #1e2937;
+}
+
+.toolbar button {
+  appearance: none;
+  background: #2b67ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-weight: 700;
+  cursor: pointer;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,17 +5,29 @@ import Console from "./pages/Console";
 import useGameState from "./hooks/useGameState";
 
 function App() {
-  const { page, setPage, onChatComplete } = useGameState();
+  const { page, setPage, onChatComplete, resetGame } = useGameState();
+
+  const handleNewGame = (): void => {
+    if (window.confirm("Start a new game?")) {
+      resetGame();
+    }
+  };
+
+  let content: JSX.Element;
+  if (page === "ad") {
+    content = <AdPage onMessageSeller={() => setPage("chat")} />;
+  } else if (page === "chat") {
+    content = <Chat onComplete={onChatComplete} />;
+  } else {
+    content = <Console />;
+  }
 
   return (
     <div className="app-container">
-      {page === "ad" ? (
-        <AdPage onMessageSeller={() => setPage("chat")} />
-      ) : page === "chat" ? (
-        <Chat onComplete={onChatComplete} />
-      ) : (
-        <Console />
-      )}
+      <div className="app-content">{content}</div>
+      <div className="toolbar">
+        <button onClick={handleNewGame}>New Game</button>
+      </div>
     </div>
   );
 }

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -7,6 +7,7 @@ interface GameState {
 }
 
 const STORAGE_KEY = "gameState";
+const INITIAL_STATE: GameState = { page: "ad" };
 
 function loadState(): GameState {
   try {
@@ -18,7 +19,7 @@ function loadState(): GameState {
   } catch {
     // ignore parsing errors and fall back to default
   }
-  return { page: "ad" };
+  return INITIAL_STATE;
 }
 
 export default function useGameState() {
@@ -36,5 +37,14 @@ export default function useGameState() {
 
   const onChatComplete = (): void => setPage("console");
 
-  return { page: state.page, setPage, onChatComplete };
+  const resetGame = (): void => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore remove errors
+    }
+    setState(INITIAL_STATE);
+  };
+
+  return { page: state.page, setPage, onChatComplete, resetGame };
 }


### PR DESCRIPTION
## Summary
- Add bottom toolbar in App with "New Game" button and confirmation
- Extend state manager with resetGame to clear progress
- Style App container and toolbar for new layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68b62c924832493f31dbf683391a3