### PR TITLE
Fix extra space in Console command line buffer

### DIFF
--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -181,7 +181,7 @@ export default function Console({ newGame }: ConsoleProps): JSX.Element {
         // Remove previous buffer characters (after last '> ')
         const idx = noCursor.lastIndexOf("> ");
         const base = noCursor.slice(0, idx + 2);
-        screen.textContent = base + " " + text;
+        screen.textContent = base + text;
         lineBuffer = text;
         renderCursor();
       }


### PR DESCRIPTION
## Summary
- fix Console setLine to avoid adding a redundant space, preventing double spacing after the DOS prompt

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b74d377a5883248986eb5428b68b5e