### PR TITLE
fix: prevent extra spaces during cursor blink

### DIFF
--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -168,10 +168,9 @@ export default function Console({ newGame }: ConsoleProps): JSX.Element {
       }
       function renderCursor() {
         // rewrite current line: remove any existing cursor char
-        const txt = screen.textContent.replace(/▌$/, "");
-        screen.textContent = txt;
-        if (promptActive) {
-          print(cursorVisible ? "▌" : " ");
+        screen.textContent = screen.textContent.replace(/▌$/, "");
+        if (promptActive && cursorVisible) {
+          print("▌");
         }
       }
 


### PR DESCRIPTION
## Summary
- stop renderCursor from adding spaces each time the cursor blinks

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b755ae24cc8324b54dd21f5d980094