### PR TITLE
Disable scrolling and use monospace font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,9 @@
 body {
   margin: 0;
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: monospace;
   line-height: 1.5;
   background: #000;
+  overflow: hidden;
 }
 
 #root {
@@ -12,4 +13,5 @@ body {
   padding: 0;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
 }

--- a/src/pages/AdPage.tsx
+++ b/src/pages/AdPage.tsx
@@ -17,7 +17,7 @@ export default function AdPage({ onMessageSeller }: { onMessageSeller: () => voi
       --radius:16px;
     }
     *{box-sizing:border-box}
-    html,body{margin:0;background:var(--bg);color:var(--text);font:16px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Inter,Arial, sans-serif}
+    html,body{margin:0;background:var(--bg);color:var(--text);font:16px/1.45 monospace}
     a{color:var(--accent);text-decoration:none}
     .wrap{max-width:960px;margin-inline:auto;padding:12px 12px 72px}
 

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -17,7 +17,7 @@ export default function Chat({ onComplete }: ChatProps): JSX.Element {
     --text:#e6edf3; --muted:#9aa7b4; --you:#1e2a38; --them:#1f2f1f; --border:#22303c;
     --shadow:0 10px 30px rgba(0,0,0,.35); --radius:16px;
     height:100%; width:100%; background:linear-gradient(180deg,#0b1117,#0e151c 40%,#0b1117);
-    color:var(--text); font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,"Helvetica Neue",Arial;
+    color:var(--text); font:16px/1.4 monospace;
     display:flex; flex-direction:column;
   }
   .baylike *, .baylike *::before, .baylike *::after{ box-sizing:border-box }
@@ -36,7 +36,7 @@ export default function Chat({ onComplete }: ChatProps): JSX.Element {
 
   .baylike .chat-head{ padding:10px 14px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center; background:linear-gradient(180deg,rgba(255,255,255,.02),transparent) }
 
-  .baylike .chat-body{ flex:1; overflow:auto; padding:14px; display:flex; flex-direction:column; gap:10px; background:radial-gradient(1200px 400px at 20% -20%, rgba(47,129,247,.07), transparent 60%) }
+  .baylike .chat-body{ flex:1; overflow:hidden; padding:14px; display:flex; flex-direction:column; gap:10px; background:radial-gradient(1200px 400px at 20% -20%, rgba(47,129,247,.07), transparent 60%) }
   /* Hide scrollbars in chat and composer textarea */
   .baylike .chat-body{ -ms-overflow-style:none; scrollbar-width:none }
   .baylike .chat-body::-webkit-scrollbar{ display:none }

--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -735,8 +735,7 @@ export default function Console({ newGame }: ConsoleProps): JSX.Element {
     box-shadow: 0 0 0 2px rgba(0,0,0,.65) inset,
                 0 0 80px rgba(0,255,130,.06) inset,
                 0 0 220px rgba(0,200,100,.05) inset;
-    overflow:auto; scroll-behavior: smooth;
-    -webkit-overflow-scrolling: touch;
+    overflow:hidden;
     filter: saturate(90%) contrast(110%) brightness(95%);
   }
   pre#screen{ margin:0; padding:16px 18px 40px; color:var(--phosphor); font-size: clamp(12px, 2.6vmin, 18px); text-shadow: 0 0 6px rgba(0,255,130,.35), 0 0 18px rgba(0,255,100,.12);


### PR DESCRIPTION
## Summary
- enforce monospace typography across app
- disable scrolling globally and within chat console

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b756112b748324b0759f833e146526