### PR TITLE
Add arrival transition screen before console page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
 import "./App.css";
 import AdPage from "./pages/AdPage";
 import Chat from "./pages/Chat";
+import Arrival from "./pages/Arrival";
 import Console from "./pages/Console";
 
 import useGameState from "./hooks/useGameState";
 
 
 function App() {
-  const { page, setPage, onChatComplete, newGame } = useGameState();
+  const { page, setPage, onChatComplete, onArrivalComplete, newGame } = useGameState();
 
   return (
     <div className="app-container">
@@ -15,6 +16,8 @@ function App() {
         <AdPage onMessageSeller={() => setPage("chat")} />
       ) : page === "chat" ? (
         <Chat onComplete={onChatComplete} />
+      ) : page === "arrival" ? (
+        <Arrival onComplete={onArrivalComplete} />
       ) : (
         <Console newGame={newGame} />
       )}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export type Page = "ad" | "chat" | "console";
+export type Page = "ad" | "chat" | "arrival" | "console";
 
 interface GameState {
   page: Page;
@@ -34,9 +34,11 @@ export default function useGameState() {
 
   const setPage = (page: Page): void => setState((prev) => ({ ...prev, page }));
 
-  const onChatComplete = (): void => setPage("console");
+  const onChatComplete = (): void => setPage("arrival");
+
+  const onArrivalComplete = (): void => setPage("console");
 
   const newGame = (): void => setState({ page: "ad" });
 
-  return { page: state.page, setPage, onChatComplete, newGame };
+  return { page: state.page, setPage, onChatComplete, onArrivalComplete, newGame };
 }

--- a/src/pages/Arrival.tsx
+++ b/src/pages/Arrival.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+interface ArrivalProps {
+  onComplete?: () => void;
+}
+
+export default function Arrival({ onComplete }: ArrivalProps): JSX.Element {
+  const [showText, setShowText] = useState(false);
+  const [fadeOut, setFadeOut] = useState(false);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setShowText(true), 100); // fade in
+    const t2 = setTimeout(() => setFadeOut(true), 2300); // start fade out
+    const t3 = setTimeout(() => {
+      if (onComplete) onComplete();
+    }, 3500); // after fade out
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [onComplete]);
+
+  const css = `
+  .arrival-screen {
+    width: 100%;
+    height: 100%;
+    background: #000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+  }
+  .arrival-text {
+    font-size: 24px;
+    opacity: 0;
+    transition: opacity 1.2s ease-in-out;
+  }
+  .arrival-text.show {
+    opacity: 1;
+  }
+  .arrival-text.fade {
+    opacity: 0;
+  }
+  `;
+
+  return (
+    <div className="arrival-screen">
+      <style>{css}</style>
+      <div
+        className={`arrival-text ${showText ? "show" : ""} ${
+          fadeOut ? "fade" : ""
+        }`}
+      >
+        3 to 5 days later. Your package arrives.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Insert arrival transition screen showing package arrival after chat ends
- Route through new arrival screen before console
- Extend game state to track new transition step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b75a753a188324a64560d71e186a64