### PR TITLE
Navigate to arrival component on Buy Now

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   return (
     <div className="app-container">
       {page === "ad" ? (
-        <AdPage onMessageSeller={() => setPage("chat")} />
+        <AdPage onMessageSeller={() => setPage("chat")} onBuyNow={() => setPage("arrival")} />
       ) : page === "chat" ? (
         <Chat onComplete={onChatComplete} />
       ) : page === "arrival" ? (

--- a/src/pages/AdPage.tsx
+++ b/src/pages/AdPage.tsx
@@ -1,4 +1,4 @@
-export default function AdPage({ onMessageSeller }: { onMessageSeller: () => void }): JSX.Element {
+export default function AdPage({ onMessageSeller, onBuyNow }: { onMessageSeller: () => void; onBuyNow: () => void }): JSX.Element {
   const css = `
     :root{
       /* Color scheme inspired by the screenshot */
@@ -123,7 +123,7 @@ export default function AdPage({ onMessageSeller }: { onMessageSeller: () => voi
               Vintage handheld computer <strong>W1‑SH</strong> from the late 1990s. Includes <strong>2×AA batteries</strong>. Screen powers on and the device should work. No manual available; seller has limited technical details.
             </p>
             <div className="cta">
-              <button className="btn primary">Buy Now</button>
+              <button className="btn primary" onClick={onBuyNow}>Buy Now</button>
               <button className="btn ghost" onClick={onMessageSeller}>Message Seller</button>
             </div>
 


### PR DESCRIPTION
## Summary
- Route Buy Now button to trigger Arrival page.
- Accept onBuyNow prop in AdPage and wire it to state management.

## Testing
- `npm test` *(fails: Missing script "test"*).
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7fa8a56448324bf82061da76e1546