### PR TITLE
Add TitleScreen component with fullscreen boot

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,21 @@ import "./App.css";
 import AdPage from "./pages/AdPage";
 import Chat from "./pages/Chat";
 import Arrival from "./pages/Arrival";
+import TitleScreen from "./pages/TitleScreen";
 import Console from "./pages/Console";
 
 import useGameState from "./hooks/useGameState";
 
 
 function App() {
-  const { page, setPage, onChatComplete, onArrivalComplete, newGame } = useGameState();
+  const {
+    page,
+    setPage,
+    onChatComplete,
+    onArrivalComplete,
+    onTitleComplete,
+    newGame,
+  } = useGameState();
 
   return (
     <div className="app-container">
@@ -18,6 +26,8 @@ function App() {
         <Chat onComplete={onChatComplete} />
       ) : page === "arrival" ? (
         <Arrival onComplete={onArrivalComplete} />
+      ) : page === "title" ? (
+        <TitleScreen onBoot={onTitleComplete} />
       ) : (
         <Console newGame={newGame} />
       )}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export type Page = "ad" | "chat" | "arrival" | "console";
+export type Page = "ad" | "chat" | "arrival" | "title" | "console";
 
 interface GameState {
   page: Page;
@@ -36,9 +36,18 @@ export default function useGameState() {
 
   const onChatComplete = (): void => setPage("arrival");
 
-  const onArrivalComplete = (): void => setPage("console");
+  const onArrivalComplete = (): void => setPage("title");
+
+  const onTitleComplete = (): void => setPage("console");
 
   const newGame = (): void => setState({ page: "ad" });
 
-  return { page: state.page, setPage, onChatComplete, onArrivalComplete, newGame };
+  return {
+    page: state.page,
+    setPage,
+    onChatComplete,
+    onArrivalComplete,
+    onTitleComplete,
+    newGame,
+  };
 }

--- a/src/pages/Arrival.tsx
+++ b/src/pages/Arrival.tsx
@@ -43,10 +43,6 @@ export default function Arrival({ onComplete }: ArrivalProps): JSX.Element {
   .arrival-text.fade {
     opacity: 0;
   }
-  .arrival-image {
-    margin-top: 20px;
-    max-width: 80%;
-  }
   `;
 
   return (
@@ -59,11 +55,6 @@ export default function Arrival({ onComplete }: ArrivalProps): JSX.Element {
       >
         3 to 5 days later. Your package arrives.
       </div>
-      <img
-        src={`${import.meta.env.BASE_URL}images/arrival-device.jpg`}
-        alt="Delivered device"
-        className="arrival-image"
-      />
     </div>
   );
 }

--- a/src/pages/TitleScreen.tsx
+++ b/src/pages/TitleScreen.tsx
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+
+interface TitleScreenProps {
+  onBoot: () => void;
+}
+
+export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
+  const handleBoot = useCallback(async () => {
+    const el = document.documentElement;
+    if (el.requestFullscreen) {
+      try {
+        await el.requestFullscreen();
+      } catch {
+        // ignore fullscreen errors
+      }
+    }
+    onBoot();
+  }, [onBoot]);
+
+  const css = `
+  .title-screen {
+    width: 100%;
+    height: 100%;
+    background: #000;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+  }
+  .arrival-image {
+    margin-top: 20px;
+    max-width: 80%;
+  }
+  .boot-button {
+    margin-top: 20px;
+    padding: 10px 20px;
+    background: #444;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+  }
+  `;
+
+  return (
+    <div className="title-screen">
+      <style>{css}</style>
+      <img
+        src={`${import.meta.env.BASE_URL}images/arrival-device.jpg`}
+        alt="Delivered device"
+        className="arrival-image"
+      />
+      <button className="boot-button" onClick={handleBoot}>
+        Boot it up!
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add TitleScreen component showing arrival device and boot button
- Route Arrival completion to new TitleScreen and then to Console
- Update game state to include new page and navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b7fb20c4e48324ae4f840571e094eb