### PR TITLE
feat: add elite and pinball commands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import AdPage from "./pages/AdPage";
 import Chat from "./pages/Chat";
 import Arrival from "./pages/Arrival";
 import TitleScreen from "./pages/TitleScreen";
+import Elite from "./pages/Elite";
+import Pinball from "./pages/Pinball";
 import Console from "./pages/Console";
 
 import useGameState from "./hooks/useGameState";
@@ -21,15 +23,22 @@ function App() {
   return (
     <div className="app-container">
       {page === "ad" ? (
-        <AdPage onMessageSeller={() => setPage("chat")} onBuyNow={() => setPage("arrival")} />
+        <AdPage
+          onMessageSeller={() => setPage("chat")}
+          onBuyNow={() => setPage("arrival")}
+        />
       ) : page === "chat" ? (
         <Chat onComplete={onChatComplete} />
       ) : page === "arrival" ? (
         <Arrival onComplete={onArrivalComplete} />
       ) : page === "title" ? (
         <TitleScreen onBoot={onTitleComplete} />
+      ) : page === "elite" ? (
+        <Elite />
+      ) : page === "pinball" ? (
+        <Pinball />
       ) : (
-        <Console newGame={newGame} />
+        <Console newGame={newGame} runGame={setPage} />
       )}
     </div>
   );

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 
-export type Page = "ad" | "chat" | "arrival" | "title" | "console";
+export type Page =
+  | "ad"
+  | "chat"
+  | "arrival"
+  | "title"
+  | "console"
+  | "elite"
+  | "pinball";
 
 interface GameState {
   page: Page;

--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -1,11 +1,13 @@
 // @ts-nocheck
 import { useEffect, useRef } from "react";
+import type { Page } from "../hooks/useGameState";
 
 interface ConsoleProps {
   newGame: () => void;
+  runGame: (page: Page) => void;
 }
 
-export default function Console({ newGame }: ConsoleProps): JSX.Element {
+export default function Console({ newGame, runGame }: ConsoleProps): JSX.Element {
   const booted = useRef(false);
   useEffect(() => {
     if (booted.current) return;
@@ -255,6 +257,12 @@ export default function Console({ newGame }: ConsoleProps): JSX.Element {
           case "RUN":
             runCmd(parts.join(" "));
             break;
+          case "ELITE":
+            runGame("elite");
+            return;
+          case "PINBALL":
+            runGame("pinball");
+            return;
           case "BEEP":
             initAudio();
             beep(880, 120);
@@ -388,6 +396,8 @@ export default function Console({ newGame }: ConsoleProps): JSX.Element {
         println(" CLS               clear screen");
         println(" VER | DATE | TIME | MEM");
         println(" RUN <NAME>        run a program (e.g., RUN DEMO)");
+        println(" ELITE             play Elite demo");
+        println(" PINBALL           play pinball game");
         println(" BEEP              beep the PC speaker");
         println(" TESTS             run built-in self tests");
         println(" REBOOT            reboot the simulated PC");


### PR DESCRIPTION
## Summary
- add `ELITE` and `PINBALL` console commands
- wire Elite and Pinball pages into game state and routing
- document new commands in console help

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe8b53a548324b2a23ed1919832df