### PR TITLE
feat: add fullscreen home menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import "./App.css";
 import AdPage from "./pages/AdPage";
 import Chat from "./pages/Chat";
@@ -6,11 +7,13 @@ import TitleScreen from "./pages/TitleScreen";
 import Elite from "./pages/Elite";
 import Pinball from "./pages/Pinball";
 import Console from "./pages/Console";
+import Home from "./pages/Home";
 
 import useGameState from "./hooks/useGameState";
 
 
 function App() {
+  const [showHome, setShowHome] = useState(true);
   const {
     page,
     setPage,
@@ -20,9 +23,31 @@ function App() {
     newGame,
   } = useGameState();
 
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      if (!document.fullscreenElement) {
+        setShowHome(true);
+      }
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  const startNewGame = () => {
+    newGame();
+    setShowHome(false);
+  };
+
+  const continueGame = () => {
+    setShowHome(false);
+  };
+
   return (
     <div className="app-container">
-      {page === "ad" ? (
+      {showHome ? (
+        <Home onNewGame={startNewGame} onContinue={continueGame} />
+      ) : page === "ad" ? (
         <AdPage
           onMessageSeller={() => setPage("chat")}
           onBuyNow={() => setPage("arrival")}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,34 @@
-export default function Home(): JSX.Element {
+import type { MouseEvent } from "react";
+
+interface HomeProps {
+  onNewGame: () => void;
+  onContinue: () => void;
+}
+
+export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element {
+  const requestFullscreen = async (): Promise<void> => {
+    const el = document.documentElement;
+    if (el.requestFullscreen) {
+      try {
+        await el.requestFullscreen();
+      } catch {
+        // ignore fullscreen errors
+      }
+    }
+  };
+
+  const handleNewGame = async (e: MouseEvent): Promise<void> => {
+    e.preventDefault();
+    await requestFullscreen();
+    onNewGame();
+  };
+
+  const handleContinue = async (e: MouseEvent): Promise<void> => {
+    e.preventDefault();
+    await requestFullscreen();
+    onContinue();
+  };
+
   const css = `
   @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
@@ -158,9 +188,19 @@ export default function Home(): JSX.Element {
       </h1>
       <nav>
         <ul className="menu">
-          <li className="menu-item"><a href="#">New Game</a></li>
-          <li className="menu-item"><a href="#">Continue</a></li>
-          <li className="menu-item"><a href="#">Options</a></li>
+          <li className="menu-item">
+            <a href="#" onClick={handleNewGame}>
+              New Game
+            </a>
+          </li>
+          <li className="menu-item">
+            <a href="#" onClick={handleContinue}>
+              Continue
+            </a>
+          </li>
+          <li className="menu-item">
+            <a href="#">Options</a>
+          </li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- show Home screen on startup with menu
- start or resume gameplay in fullscreen
- return to Home when fullscreen exits

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbeaee5fbc8324bd70b8179e6c652c