### PR TITLE
feat: add basic pwa support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>W1SH</title>
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "W1SH",
+  "short_name": "W1SH",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "W1SH progressive web app",
+  "icons": [
+    {
+      "src": "/images/w1sh-ad2.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'w1sh-cache-v1';
+const URLS_TO_CACHE = ['/'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,9 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <App />
   </React.StrictMode>
 );
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js");
+  });
+}


### PR DESCRIPTION
## Summary
- link to web app manifest and theme color in index
- register service worker for offline use
- add manifest and service worker for caching

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68bbfbe4a1e88324b4c1253a22387a16