### PR TITLE
fix: use relative PWA paths

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -7,7 +7,7 @@
   "description": "W1SH progressive web app",
   "icons": [
     {
-      "src": "/images/w1sh-ad2.png",
+      "src": "images/w1sh-ad2.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,6 @@
 const CACHE_NAME = 'w1sh-cache-v1';
-const URLS_TO_CACHE = ['/'];
+const BASE_PATH = self.location.pathname.replace(/sw\.js$/, '');
+const URLS_TO_CACHE = [BASE_PATH];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,6 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/sw.js");
+    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`);
   });
 }


### PR DESCRIPTION
## Summary
- register service worker using Vite's base path
- convert PWA asset URLs to relative paths
- cache correct base path in service worker

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbfe62a9a48324a1455c31e121fec3