### PR TITLE
feat: add exit button to pinball

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App() {
       ) : page === "elite" ? (
         <Elite />
       ) : page === "pinball" ? (
-        <Pinball />
+        <Pinball setPage={setPage} />
       ) : (
         <Console newGame={newGame} runGame={setPage} />
       )}

--- a/src/pages/Pinball.tsx
+++ b/src/pages/Pinball.tsx
@@ -65,6 +65,17 @@ html,
         right: 10px;
         pointer-events: auto;
         cursor: pointer;
+        background: #22c55e;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        padding: 10px 20px;
+        font-weight: bold;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+        transition: background 0.2s;
+      }
+      #exit-btn:hover {
+        background: #16a34a;
       }
   `;
 

--- a/src/pages/Pinball.tsx
+++ b/src/pages/Pinball.tsx
@@ -1,7 +1,10 @@
 // @ts-nocheck
 import { useEffect } from "react";
+import useGameState from "../hooks/useGameState";
 
 export default function Pinball(): JSX.Element {
+  const { setPage } = useGameState();
+  const handleExit = () => setPage("console");
   const css = `
 html,
       body {
@@ -55,6 +58,13 @@ html,
         left: 50%;
         top: 50%;
         transform: translate(-50%, -50%);
+      }
+      #exit-btn {
+        position: fixed;
+        bottom: 10px;
+        right: 10px;
+        pointer-events: auto;
+        cursor: pointer;
       }
   `;
 
@@ -817,6 +827,9 @@ html,
     <div>
       <style>{css}</style>
       <canvas id="c"></canvas>
+      <button id="exit-btn" className="panel" onClick={handleExit}>
+        Exit
+      </button>
       <div id="ui">
       <div className="panel" id="score">Score: 0</div>
       <div className="panel" id="balls">Balls: ∞</div>

--- a/src/pages/Pinball.tsx
+++ b/src/pages/Pinball.tsx
@@ -2,8 +2,9 @@
 import { useEffect } from "react";
 import useGameState from "../hooks/useGameState";
 
-export default function Pinball(): JSX.Element {
-  const { setPage } = useGameState();
+import type { Page } from "../hooks/useGameState";
+
+export default function Pinball({ setPage }: { setPage: (page: Page) => void }): JSX.Element {
   const handleExit = () => setPage("console");
   const css = `
 html,


### PR DESCRIPTION
## Summary
- add useGameState-driven exit button to Pinball that returns players to the DOS console
- style exit button as overlay panel positioned at bottom-right of the game

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bca17b0fc0832499394fed7fe271e4