### PR TITLE
refactor: extract console screen component

### DIFF
--- a/src/components/ConsoleScreen.tsx
+++ b/src/components/ConsoleScreen.tsx
@@ -1,0 +1,3 @@
+export default function ConsoleScreen(): JSX.Element {
+  return <pre id="screen"></pre>;
+}

--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { useEffect, useRef } from "react";
 import type { Page } from "../hooks/useGameState";
+import ConsoleScreen from "../components/ConsoleScreen";
 
 interface ConsoleProps {
   newGame: () => void;
@@ -839,7 +840,7 @@ export default function Console({
       <div className="wrap">
         <div className="crt" id="crt">
           <div className="inner">
-            <pre id="screen"></pre>
+            <ConsoleScreen />
           </div>
           <div className="function-keys">
             <span>


### PR DESCRIPTION
## Summary
- factor out the `<pre id="screen">` element into a reusable `ConsoleScreen` component
- use the new `ConsoleScreen` component within `Console` page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bca369ca5083248efc8746c0c88008