### PR TITLE
feat: style title screen

### DIFF
--- a/src/pages/TitleScreen.tsx
+++ b/src/pages/TitleScreen.tsx
@@ -10,37 +10,132 @@ export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
   }, [onBoot]);
 
   const css = `
-  .title-screen {
-    width: 100%;
+  @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+
+  /* --- Basic Setup & Resets --- */
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html, body {
     height: 100%;
-    background: #000;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  body {
+    background-color: #050a05;
+    color: #00ff41;
+    font-family: 'VT323', monospace;
+    text-transform: uppercase;
+  }
+
+  /* --- Main Terminal Container --- */
+  .terminal-container {
     display: flex;
     flex-direction: column;
-    align-items: center;
     justify-content: center;
-    color: #fff;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 20px;
+    position: relative;
   }
+
+  /* --- CRT Screen Effects --- */
+  .terminal-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-shadow: inset 0 0 10em 1em #000;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .terminal-container::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: repeating-linear-gradient(
+      transparent 0,
+      rgba(0, 0, 0, 0.4) 1px,
+      transparent 2px
+    );
+    background-size: 100% 3px;
+    opacity: 0.8;
+    pointer-events: none;
+    z-index: 2;
+    animation: flicker 0.15s infinite;
+  }
+
+  @keyframes flicker {
+    0% { opacity: 0.75; }
+    50% { opacity: 0.85; }
+    100% { opacity: 0.75; }
+  }
+
   .arrival-image {
+    width: 306px;
+    height: 460px;
     margin-top: 20px;
-    max-width: 80%;
+    object-fit: cover;
   }
+
   .boot-button {
+    position: relative;
+    display: inline-block;
     margin-top: 20px;
-    padding: 10px 20px;
-    background: #444;
-    color: #fff;
+    padding: 0.5rem 1rem;
+    background-color: transparent;
+    color: #00ff41;
     border: none;
     cursor: pointer;
+    font-size: 5vw;
+    text-shadow: 0 0 5px #00ff41;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .boot-button:hover {
+    background-color: rgba(0, 255, 65, 0.1);
+    text-shadow: 0 0 5px #00ff41, 0 0 15px #00ff41;
+  }
+
+  .boot-button::before {
+    content: '>';
+    position: absolute;
+    left: -1ch;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  .boot-button:hover::before {
+    opacity: 1;
+  }
+
+  @media (min-width: 768px) {
+    .boot-button {
+      font-size: 2rem;
+    }
   }
   `;
 
   return (
-    <div className="title-screen">
+    <div className="terminal-container">
       <style>{css}</style>
       <img
         src={`${import.meta.env.BASE_URL}images/arrival-device.jpg`}
         alt="Delivered device"
         className="arrival-image"
+        width={306}
+        height={460}
       />
       <button className="boot-button" onClick={handleBoot}>
         Boot it up!


### PR DESCRIPTION
## Summary
- restyle TitleScreen using Home's terminal aesthetic
- lock arrival image to 306x460 pixels

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4903fd16883248aac5fa02606f450