### PR TITLE
Enable fullscreen pinball with F1–F5 exit controls

### DIFF
--- a/src/pages/Console.tsx
+++ b/src/pages/Console.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import type { Page } from "../hooks/useGameState";
 import ConsoleScreen from "../components/ConsoleScreen";
 import CommandChips from "../components/CommandChips";
@@ -63,6 +63,23 @@ export default function Console({ newGame, runGame: runPage }: ConsoleProps): JS
     setLine,
     runCommand,
   });
+
+  const pinballChipCommands = useMemo(
+    () => [
+      { text: "", onPress: () => {} },
+      { text: "", onPress: () => {} },
+      { text: "", onPress: () => {} },
+      { text: "", onPress: () => {} },
+      {
+        text: "EXIT",
+        onPress: () => {
+          setActiveGame(null);
+          startPrompt();
+        },
+      },
+    ],
+    [startPrompt]
+  );
 
   // ---------- Physical keyboard ----------
   useEffect(() => {
@@ -157,6 +174,10 @@ export default function Console({ newGame, runGame: runPage }: ConsoleProps): JS
   .chip{ background:linear-gradient(180deg, #555, #444); color:#dcdcdc; border:1px solid #333; border-bottom-color:#222; border-radius:6px; padding:8px 0; font-weight:normal; letter-spacing:.6px; box-shadow:0 3px 0 #2a2a2a, 0 0 0 2px #202020 inset; text-transform:uppercase; user-select:none; touch-action:manipulation; -webkit-tap-highlight-color:transparent; cursor:pointer; text-align:center; }
   .chip:active{ transform:translateY(1px); box-shadow:0 2px 0 #2a2a2a, 0 0 0 2px #202020 inset; }
 
+  .pinball-overlay{ position:fixed; inset:0; background:#0b0f1a; display:flex; flex-direction:column; z-index:999; }
+  .pinball-overlay .pinball-area{ flex:1 1 auto; }
+  .pinball-overlay .bar{ margin:8px; }
+
   /* --- Keyboard --- */
   .rows{ display:flex; flex-direction:column; gap:6px; flex:1; }
   .row{ display:flex; gap:6px; justify-content:center; }
@@ -196,19 +217,23 @@ export default function Console({ newGame, runGame: runPage }: ConsoleProps): JS
   return (
     <>
       <style>{css}</style>
+      {activeGame === "pinball" && (
+        <div className="pinball-overlay">
+          <div className="pinball-area">
+            <Pinball
+              onExit={() => {
+                setActiveGame(null);
+                startPrompt();
+              }}
+            />
+          </div>
+          <CommandChips chipCommands={pinballChipCommands} />
+        </div>
+      )}
       <div className="wrap">
         <div className="crt">
           <div className="inner">
-            {activeGame === "pinball" ? (
-              <Pinball
-                onExit={() => {
-                  setActiveGame(null);
-                  startPrompt();
-                }}
-              />
-            ) : (
-              <ConsoleScreen>{renderWithCursor}</ConsoleScreen>
-            )}
+            <ConsoleScreen>{renderWithCursor}</ConsoleScreen>
           </div>
           {!activeGame && (
             <div className="function-keys">

--- a/src/pages/Pinball.tsx
+++ b/src/pages/Pinball.tsx
@@ -1,8 +1,7 @@
 // @ts-nocheck
 import { useEffect, useRef, useState } from "react";
 
-export default function Pinball({ onExit }: { onExit: () => void }): JSX.Element {
-  const handleExit = onExit;
+export default function Pinball({ onExit: _onExit }: { onExit: () => void }): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [score, setScore] = useState(0);
   const css = `
@@ -58,24 +57,6 @@ export default function Pinball({ onExit }: { onExit: () => void }): JSX.Element
         left: 50%;
         top: 50%;
         transform: translate(-50%, -50%);
-      }
-      .pinball-container #exit-btn {
-        position: absolute;
-        bottom: 10px;
-        right: 10px;
-        pointer-events: auto;
-        cursor: pointer;
-        background: #22c55e;
-        color: white;
-        border: none;
-        border-radius: 6px;
-        padding: 10px 20px;
-        font-weight: bold;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-        transition: background 0.2s;
-      }
-      .pinball-container #exit-btn:hover {
-        background: #16a34a;
       }
   `;
 
@@ -843,14 +824,11 @@ export default function Pinball({ onExit }: { onExit: () => void }): JSX.Element
     <div className="pinball-container">
       <style>{css}</style>
       <canvas id="c" ref={canvasRef}></canvas>
-      <button id="exit-btn" className="panel" onClick={handleExit}>
-        Exit
-      </button>
       <div id="ui">
         <div className="panel" id="score">Score: {score}</div>
         <div className="panel" id="balls">Balls: ∞</div>
       </div>
-      <div id="hint">Tap left/right to flip • Higher bumpers pay up to 1000x</div>
+      <div id="hint">Tap left/right to flip • Higher bumpers pay up to 1000x • F5 Exit</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- launch pinball in a fullscreen overlay
- show F1–F5 chip bar with F5 exiting the game
- remove in-game exit button and hint players to use F5

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4992dcd38832480470e75f452d35a