### PR TITLE
docs: use yarn instead of npm

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,7 @@ These guidelines capture the project-specific architecture and conventions for t
 6. Optionally craft chip shortcut by adding `.EXE` in current dir so RUN mode lists it.
 
 ## Build & Dev
-- Scripts: `npm run dev` (Vite), `npm run build` (TypeScript compile then Vite), `npm run preview` (serve build). No tests currently; avoid inventing a test harness unless requested.
+- Scripts: `yarn dev` (Vite), `yarn build` (TypeScript compile then Vite), `yarn preview` (serve build). No tests currently; avoid inventing a test harness unless requested.
 - Service worker auto-registered on load for PWA-like caching; keep path relative to `import.meta.env.BASE_URL`.
 
 ## Style & Implementation Notes

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Logs
 logs
 *.log
-npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
@@ -47,9 +46,6 @@ web_modules/
 # TypeScript cache
 *.tsbuildinfo
 
-# Optional npm cache directory
-.npm
-
 # Optional eslint cache
 .eslintcache
 
@@ -59,7 +55,7 @@ web_modules/
 # Optional REPL history
 .node_repl_history
 
-# Output of 'npm pack'
+# Output of 'yarn pack'
 *.tgz
 
 # Yarn Integrity file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ Provide concise, surgical help adding narrative screens, DOS shell commands, vir
 - Writing animations that append indefinitely → memory growth.
 
 ## Quick Reference
-- Dev: `npm run dev`
-- Build: `npm run build`
-- Preview: `npm run preview`
+- Dev: `yarn dev`
+- Build: `yarn build`
+- Preview: `yarn preview`
 
 Keep changes atomic; submit diffs only for touched regions. Ask before broad structural shifts.

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ A simple React application built with [Vite](https://vitejs.dev/) and TypeScript
 1. Install dependencies:
 
    ```bash
-   npm install
+   yarn install
    ```
 
 2. Start the development server:
 
    ```bash
-   npm run dev
+   yarn dev
    ```
 
 3. Create a production build:
 
    ```bash
-   npm run build
+   yarn build
    ```
 
 ## Deployment
@@ -29,6 +29,6 @@ This project is deployed to GitHub Pages. The site is automatically built and pu
 To preview the production build locally:
 
 ```bash
-npm run build
-npm run preview
+yarn build
+yarn preview
 ```


### PR DESCRIPTION
## Summary
- replace npm commands with yarn in project docs and instructions
- remove npm-specific entries from `.gitignore`

## Testing
- ⚠️ `yarn build` *(command not found: yarn)*
- ⚠️ `apt-get update` *(repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c533b7d8a883248d2b00d3c5b071b8