### PR TITLE
Enforce consistent portrait scaling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,10 @@
 .app-container {
-  width: min(100vw, calc(100vh * 9 / 16));
-  aspect-ratio: 9 / 16;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 360px;
+  height: 640px;
+  transform-origin: top left;
+  transform: translate(-50%, -50%) scale(var(--app-scale));
   display: flex;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,22 @@ function App() {
   } = useGameState();
 
   useEffect(() => {
+    const updateScale = () => {
+      const scale = Math.min(
+        window.innerWidth / 360,
+        window.innerHeight / 640
+      );
+      document.documentElement.style.setProperty(
+        "--app-scale",
+        scale.toString()
+      );
+    };
+    updateScale();
+    window.addEventListener("resize", updateScale);
+    return () => window.removeEventListener("resize", updateScale);
+  }, []);
+
+  useEffect(() => {
     const handleFullscreenChange = () => {
       if (!document.fullscreenElement) {
         setShowHome(true);

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,17 @@
+:root {
+  --app-scale: 1;
+}
+
 body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   background: #000;
+  overflow: hidden;
 }
 
 #root {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0;
+  position: relative;
   width: 100vw;
   height: 100vh;
 }

--- a/src/pages/Elite.tsx
+++ b/src/pages/Elite.tsx
@@ -12,8 +12,8 @@ export default function Elite(): JSX.Element {
       font-size: 10px;
       line-height: 1.6;
       position: relative;
-      width: 100vw;
-      height: 100vh;
+      width: 100%;
+      height: 100%;
     }
     canvas {
       display: block;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -161,7 +161,7 @@ export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element 
 
   /* --- Game Title --- */
   .game-title {
-    font-size: 12vw; /* Responsive font size */
+    font-size: 44px;
     font-weight: normal;
     letter-spacing: 0.5rem;
     text-shadow:
@@ -197,7 +197,7 @@ export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element 
     display: inline-block;
     color: #00ff41;
     text-decoration: none;
-    font-size: 5vw; /* Responsive font size */
+    font-size: 18px;
     padding: 0.5rem 1rem;
     margin: 0.5rem 0;
     transition: all 0.2s ease-in-out;

--- a/src/pages/TitleScreen.tsx
+++ b/src/pages/TitleScreen.tsx
@@ -92,7 +92,7 @@ export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
     color: #00ff41;
     background: none;
     border: none;
-    font-size: 5vw;
+    font-size: 18px;
     padding: 0.5rem 1rem;
     margin: 0.5rem 0;
     transition: all 0.2s ease-in-out;
@@ -117,11 +117,6 @@ export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
     opacity: 1;
   }
 
-  @media (min-width: 768px) {
-    .boot-button {
-      font-size: 2rem;
-    }
-  }
   `;
 
   return (


### PR DESCRIPTION
## Summary
- Scale entire app to a fixed 360x640 portrait frame for uniform look across resolutions
- Replace viewport-relative fonts with fixed sizes in Home and Title screens
- Make Elite page fill the scaled container instead of viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c53580d7e08324b022beae03164703