### PR TITLE
Keep text proportions consistent across screen sizes

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -161,7 +161,7 @@ export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element 
 
   /* --- Game Title --- */
   .game-title {
-    font-size: 12vw; /* Responsive font size */
+    font-size: calc(min(100vw, 100vh * 9 / 16) * 0.12);
     font-weight: normal;
     letter-spacing: 0.5rem;
     text-shadow:
@@ -197,7 +197,7 @@ export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element 
     display: inline-block;
     color: #00ff41;
     text-decoration: none;
-    font-size: 5vw; /* Responsive font size */
+    font-size: calc(min(100vw, 100vh * 9 / 16) * 0.05);
     padding: 0.5rem 1rem;
     margin: 0.5rem 0;
     transition: all 0.2s ease-in-out;
@@ -229,15 +229,6 @@ export default function Home({ onNewGame, onContinue }: HomeProps): JSX.Element 
     opacity: 1;
   }
 
-  /* --- Media Queries for Different Screen Sizes --- */
-  @media (min-width: 768px) {
-    .game-title {
-      font-size: 7rem; /* Fixed size for larger screens */
-    }
-    .menu-item a {
-      font-size: 2rem; /* Fixed size for larger screens */
-    }
-  }
   `;
 
   return (

--- a/src/pages/TitleScreen.tsx
+++ b/src/pages/TitleScreen.tsx
@@ -92,7 +92,7 @@ export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
     color: #00ff41;
     background: none;
     border: none;
-    font-size: 5vw;
+    font-size: calc(min(100vw, 100vh * 9 / 16) * 0.05);
     padding: 0.5rem 1rem;
     margin: 0.5rem 0;
     transition: all 0.2s ease-in-out;
@@ -117,11 +117,6 @@ export default function TitleScreen({ onBoot }: TitleScreenProps): JSX.Element {
     opacity: 1;
   }
 
-  @media (min-width: 768px) {
-    .boot-button {
-      font-size: 2rem;
-    }
-  }
   `;
 
   return (


### PR DESCRIPTION
## Summary
- Scale title screen boot button font by the app's 9:16 viewport so it stays proportional on any device
- Apply the same aspect-based scaling to the home screen title and menu items

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c53580d7e08324b022beae03164703