### PR TITLE
Refine TicTacToe opening move and cursor

### DIFF
--- a/src/pages/TicTacToe.tsx
+++ b/src/pages/TicTacToe.tsx
@@ -159,8 +159,14 @@ export default function TicTacToe({
       document.body.style.pointerEvents = "none";
 
       setTimeout(() => {
-        const bestMove = minimax(board, computer);
-        updateBoard(bestMove.index, computer);
+        let moveIndex: number;
+        if (board.every((cell) => cell === "")) {
+          const firstMoves = [2, 6, 8];
+          moveIndex = firstMoves[Math.floor(Math.random() * firstMoves.length)];
+        } else {
+          moveIndex = minimax(board, computer).index;
+        }
+        updateBoard(moveIndex, computer);
         if (checkResult()) return;
         statusMessage.textContent = "YOUR TURN (O)";
         document.body.style.pointerEvents = "auto";
@@ -342,7 +348,7 @@ export default function TicTacToe({
         .outer-cell {
             border: 1px dashed transparent;
             animation: border-flicker 2s linear infinite;
-            cursor: help;
+            cursor: default;
         }
 
         .outer-cell:hover {


### PR DESCRIPTION
## Summary
- Remove confusing help cursor from outer TicTacToe cells
- Improve AI by avoiding top-left opening and picking other corners

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'vitest' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c5725cdca8832485c1876b0584acb6